### PR TITLE
Use registerTwigExtension()

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -42,7 +42,7 @@ class Plugin extends \craft\base\Plugin
         parent::init();
 
         // Add in our Twig extensions
-        Craft::$app->view->twig->addExtension(new AgnosticFetchTwigExtension());
+        Craft::$app->view->registerTwigExtension(new AgnosticFetchTwigExtension());
     }
 
     /**


### PR DESCRIPTION
Fixes a bug where the plugin may cause Twig to be loaded before it should be, and another bug where the extension might not be available if the Template Mode ever changes from CP to Site, or vise-versa.